### PR TITLE
Adds AlignContent editor component

### DIFF
--- a/src/myComponents/MarkdownRenderer.js
+++ b/src/myComponents/MarkdownRenderer.js
@@ -1,0 +1,17 @@
+import Markdown from 'markdown-to-jsx'
+import React from 'react'
+
+import AlignContent from './markdownRenderer/AlignContent'
+
+const MarkdownRenderer = ({ md }) => (
+  <Markdown
+    children={md}
+    options={{
+      overrides: {
+        AlignContent
+      }
+    }}
+  />
+)
+
+export default MarkdownRenderer

--- a/src/myComponents/markdownRenderer/AlignContent.css
+++ b/src/myComponents/markdownRenderer/AlignContent.css
@@ -1,0 +1,11 @@
+.tng-AlignContent--left + * {
+  text-align: left;
+}
+
+.tng-AlignContent--center + * {
+  text-align: center;
+}
+
+.tng-AlignContent--right + * {
+  text-align: right;
+}

--- a/src/myComponents/markdownRenderer/AlignContent.js
+++ b/src/myComponents/markdownRenderer/AlignContent.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import './AlignContent.css'
+
+const AlignContent = ({ align }) => (
+  <div className={`tng-AlignContent tng-AlignContent--${align.toLowerCase()}`} />
+)
+
+export default AlignContent

--- a/src/myPages/Admin.js
+++ b/src/myPages/Admin.js
@@ -3,6 +3,7 @@ import './admin/setup'
 import CMS, { init } from 'netlify-cms'
 
 import Article from './Article'
+import EditorAlignContent from './admin/EditorAlignContent'
 import PreviewContainer from './admin/PreviewContainer'
 import config from './admin/config'
 
@@ -11,6 +12,7 @@ CMS.init = init
 class Admin extends Component {
   componentDidMount () {
     CMS.init({ config })
+
     CMS.registerPreviewTemplate('articles', ({ entry, getAsset }) => {
       const previewData = entry.toJS().data
       previewData.mainImage = previewData.mainImage && getAsset(previewData.mainImage).toString()
@@ -21,6 +23,8 @@ class Admin extends Component {
         </PreviewContainer>
       )
     })
+
+    CMS.registerEditorComponent(EditorAlignContent)
   }
 
   render () {

--- a/src/myPages/admin/EditorAlignContent.js
+++ b/src/myPages/admin/EditorAlignContent.js
@@ -1,0 +1,22 @@
+export default {
+  id: 'alignContent',
+  label: 'Align Content',
+  fields: [
+    {
+      name: 'align',
+      label: 'Align Content Below',
+      widget: 'select',
+      options: [
+        { label: 'Left', value: 'LEFT' },
+        { label: 'Center', value: 'CENTER' },
+        { label: 'Right', value: 'RIGHT' }
+      ]
+    }
+  ],
+  pattern: /^<AlignContent\s+align="([A-Z]+)"\s+\/>/,
+  fromBlock: regexMatch => ({
+    align: regexMatch[1]
+  }),
+  toBlock: fields => `<AlignContent align="${fields.align}" />`,
+  toPreview: () => `<div></div>` // will be overriden by MarkdownRenderer
+}

--- a/src/myPages/article/ArticleContent.js
+++ b/src/myPages/article/ArticleContent.js
@@ -1,6 +1,6 @@
-import Markdown from 'markdown-to-jsx'
 import React, { Component } from 'react'
 
+import MarkdownRenderer from 'myComponents/MarkdownRenderer'
 import logoImg from 'myAssets/images/Logo-x45.png'
 import './ArticleContent.css'
 
@@ -92,7 +92,7 @@ class ArticleContent extends Component {
           <div className='tng-ArticleContent-publishDate'>published on {publicationDate}</div>
         </div>
         <div className='tng-ArticleContent-text'>
-          <Markdown>{ body || '' }</Markdown>
+          <MarkdownRenderer md={body || ''} />
         </div>
       </div>
     )


### PR DESCRIPTION
This addresses enhancement #3 

Changes:
- Adds a new Editor component for NetlifyCMS, EditorAlignContent
- Adds a new component, MarkdownRenderer, to render any Markdown body coming from NetlifyCMS
- Adds a new component, AlignContent, that will just overwrite the text-align CSS property of the next element in the body