### PR TITLE
23: Add space between consecutive EmbeddedMusic items

### DIFF
--- a/src/myComponents/MarkdownRenderer.css
+++ b/src/myComponents/MarkdownRenderer.css
@@ -6,6 +6,10 @@
   display: block;
 }
 
+.tng-MarkdownRenderer-music + .tng-MarkdownRenderer-music {
+  margin-top: 16px;
+}
+
 .tng-MarkdownRenderer-img {
   max-width: 100%;
 }

--- a/src/myComponents/PageLinks.js
+++ b/src/myComponents/PageLinks.js
@@ -16,4 +16,3 @@ const PageLinks = ({ links }) => (
 )
 
 export default PageLinks
-

--- a/src/myComponents/markdownRenderer/EmbeddedMusic.js
+++ b/src/myComponents/markdownRenderer/EmbeddedMusic.js
@@ -1,3 +1,7 @@
+/**
+ * This is a component that renders a iframe, that should have music, within our Markdown content.
+ * It will have a title and track number that will only show up with Music Only mode active.
+ */
 import React, { Component } from 'react'
 
 import sc from 'myUtils/suitClass'


### PR DESCRIPTION
This fixes two consecutive media items being right on top of each other, in the articles.