### PR TITLE
46: Fix the About preview in the CMS

### DIFF
--- a/src/myPages/Admin.js
+++ b/src/myPages/Admin.js
@@ -1,13 +1,14 @@
+/** Admin loads NetlifyCMS and sets custom widgets and templates for the CMS */
 import React, { Component } from 'react'
 import { Titled } from 'react-titled'
 import './admin/setup'
 import CMS, { init } from 'netlify-cms'
 
-import Article from './Article'
+import AboutPreview from './admin/AboutPreview'
+import ArticlePreview from './admin/ArticlePreview'
 import EditorEmbeddedMusic from './admin/EditorEmbeddedMusic'
 import EditorSpecialText from './admin/EditorSpecialText'
 import LimitedText from './admin/LimitedText'
-import PreviewContainer from './admin/PreviewContainer'
 import config from './admin/config'
 
 CMS.init = init
@@ -21,21 +22,8 @@ class Admin extends Component {
 
     CMS.registerWidget('text160Limit', LimitedText(160))
 
-    CMS.registerPreviewTemplate('articles', ({ entry, getAsset }) => {
-      const article = entry.toJS().data
-      article.mainImage = article.mainImage && getAsset(article.mainImage).toString()
-
-      const articleRelated = {
-        nextArticle: { title: 'A History Of Drum Machines', urlPath: '/no-content' },
-        previousArticle: { title: 'A Map Of Electronic Scenes', urlPath: '/no-content' }
-      }
-
-      return (
-        <PreviewContainer>
-          <Article previewData={{ article, articleRelated }} />
-        </PreviewContainer>
-      )
-    })
+    CMS.registerPreviewTemplate('about', AboutPreview)
+    CMS.registerPreviewTemplate('articles', ArticlePreview)
   }
 
   render () {

--- a/src/myPages/Home.js
+++ b/src/myPages/Home.js
@@ -10,7 +10,6 @@ import * as StickyBar from 'myComponents/StickyBar'
 import WideLogo from 'myComponents/WideLogo'
 import { categoryTexts } from 'myUtils/constants'
 
-import logoImg from 'myAssets/images/Logo-x45.png'
 import './Home.css'
 
 class Home extends Component {

--- a/src/myPages/admin/AboutPreview.js
+++ b/src/myPages/admin/AboutPreview.js
@@ -1,0 +1,18 @@
+/** AboutPreview is a custom NetlifyCMS preview template to show the About page */
+import React from 'react'
+
+import About from 'myPages/About'
+import PreviewContainer from './PreviewContainer'
+
+const AboutPreview = ({ entry, getAsset }) => {
+  const previewData = entry.toJS().data
+  previewData.mainImage = previewData.mainImage && getAsset(previewData.mainImage).toString()
+
+  return (
+    <PreviewContainer>
+      <About previewData={previewData} />
+    </PreviewContainer>
+  )
+}
+
+export default AboutPreview

--- a/src/myPages/admin/ArticlePreview.js
+++ b/src/myPages/admin/ArticlePreview.js
@@ -1,0 +1,23 @@
+/** ArticlePreview is a custom NetlifyCMS preview template to show the Article page */
+import React from 'react'
+
+import Article from 'myPages/Article'
+import PreviewContainer from './PreviewContainer'
+
+const ArticlePreview = ({ entry, getAsset }) => {
+  const article = entry.toJS().data
+  article.mainImage = article.mainImage && getAsset(article.mainImage).toString()
+
+  const articleRelated = {
+    nextArticle: { title: 'A History Of Drum Machines', urlPath: '/no-content' },
+    previousArticle: { title: 'A Map Of Electronic Scenes', urlPath: '/no-content' }
+  }
+
+  return (
+    <PreviewContainer>
+      <Article previewData={{ article, articleRelated }} />
+    </PreviewContainer>
+  )
+}
+
+export default ArticlePreview


### PR DESCRIPTION
Changes:
- Set up the About preview properly within the CMS
- Set the article preview template to its own file