### PR TITLE
38 pt 2: For desktop, layout articles in Home on 2 columns

### DIFF
--- a/src/myComponents/ArticleHeader.css
+++ b/src/myComponents/ArticleHeader.css
@@ -4,81 +4,65 @@
 }
 
 .tng-ArticleHeader-imgContainer {
-  display: flex;
-  height: 66.66vw;
-  justify-content: center;
-  max-height: 520px;
-  overflow: hidden;
+  height: 0;
+  padding-bottom: 66.67%;
   position: relative;
+}
+
+.tng-ArticleHeader-imgContainerInner {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
   text-align: center;
+  top: 0;
+  width: 100%;
 }
 
 .tng-ArticleHeader-image {
   border-color: white;
   border-style: solid;
   border-width: 0 3px;
-  height: 66.66vw;
-  max-height: 520px;
-  position: relative;
+  height: 100%;
   width: auto;
   z-index: 1;
 }
 
 .tng-ArticleHeader-imgBackground {
   background-position: top left;
-  background-size: 100vw auto;
-  height: 66.66vw;
+  background-size: 200% auto;
+  height: 100%;
   left: 0;
-  max-height: 520px;
   opacity: 0.8;
   position: absolute;
   top: 0;
   transition: transform 1200ms;
-  width: 50vw;
+  width: 50%;
   z-index: 0;
 }
 
 .tng-ArticleHeader-imgBackground--right {
   background-position: top right;
-  left: 50vw;
+  left: 50%;
 }
 
 .tng-ArticleHeader-titleBox {
   background-color: hsl(0, 0%, 98%);
-  border-top: 1px solid hsla(0, 0%, 0%, 10%);
   color: hsl(138, 82%, 28%);
   max-width: 650px;
   min-height: 30px;
   padding: 10px 15px 0;
   position: relative;
   top: -30px;
-  width: calc(100vw - 15px);
+  width: 90%;
   z-index: 2;
 }
 
 .tng-ArticleHeader-title {
-  font-family: "Lora";
+  font-family: "Lora", serif;
   font-size: 1.5em;
   font-weight: 600;
   letter-spacing: 0.5px;
-}
-
-@media (min-width: 781px) {
-  /* Set the image height to a fixed size */
-  .tng-ArticleHeader-imgContainer,
-  .tng-ArticleHeader-image,
-  .tng-ArticleHeader-imgBackground {
-    height: 520px;
-  }
-
-  /* Set the img background size to a fixed size */
-  .tng-ArticleHeader-imgBackground {
-    background-size: 780px auto;
-    width: 390px;
-  }
-
-  /* Set the left offset to a fixed size */
-  .tng-ArticleHeader-imgBackground--right {
-    left: 390px;
-  }
 }

--- a/src/myComponents/ArticleHeader.js
+++ b/src/myComponents/ArticleHeader.js
@@ -16,15 +16,10 @@ class ArticleHeader extends Component {
 
   componentDidMount () {
     this.setBackgroundImagesShift()
-    window.addEventListener('resize', this.setBackgroundImagesShift);
-  }
-
-  componentWillUnmount () {
-    window.removeEventListener('resize', this.setBackgroundImagesShift);
   }
 
   /**
-   * check the dimensions of the image, to figure out how much to shift the adjacent
+   * check the aspect ratio of the image, to figure out how much to shift the adjacent
    * background images, which creates a cool effect
    */
   setBackgroundImagesShift = () => {
@@ -32,12 +27,12 @@ class ArticleHeader extends Component {
     const img = new window.Image()
 
     img.onload = function () {
-      // according to our CSS, the image height will be 66.66vw or 520px, whichever is smaller
-      const renderedHeight = Math.min(Math.abs(0.6666 * window.innerWidth), 520)
+      const containerAspectRatio = 1.5
+      const imageAspectRatio = this.width / this.height
 
-      // We need to shift our background image by half of the image's rendered width
-      const renderedWidth = this.width * (renderedHeight / this.height)
-      component.setState({ bgShift: renderedWidth * 0.5 })
+      if (imageAspectRatio < containerAspectRatio) {
+        component.setState({ bgShift: imageAspectRatio * 100 / containerAspectRatio })
+      }
     }
 
     img.src = this.props.image
@@ -50,20 +45,22 @@ class ArticleHeader extends Component {
     let bgLStyle = { backgroundImage: `url(${image})` }
     let bgRStyle = { ...bgLStyle }
     if (bgShift) {
-      bgLStyle.transform = `translate3d(-${bgShift}px, 0, 0)`
-      bgRStyle.transform = `translate3d(${bgShift}px, 0, 0)`
+      bgLStyle.transform = `translate3d(-${bgShift}%, 0, 0)`
+      bgRStyle.transform = `translate3d(${bgShift}%, 0, 0)`
     }
 
     return (
       <div className='tng-ArticleHeader'>
         <OptionalLinkWrapper link={link}>
           <div className='tng-ArticleHeader-imgContainer'>
-            <div className='tng-ArticleHeader-imgBackground' style={bgLStyle} />
-            <div
-              className='tng-ArticleHeader-imgBackground tng-ArticleHeader-imgBackground--right'
-              style={bgRStyle}
-            />
-            <img alt='' className='tng-ArticleHeader-image' src={image} />
+            <div className='tng-ArticleHeader-imgContainerInner'>
+              <div className='tng-ArticleHeader-imgBackground' style={bgLStyle} />
+              <div
+                className='tng-ArticleHeader-imgBackground tng-ArticleHeader-imgBackground--right'
+                style={bgRStyle}
+              />
+              <img alt='' className='tng-ArticleHeader-image' src={image} />
+            </div>
           </div>
         </OptionalLinkWrapper>
         <div className='tng-ArticleHeader-titleBox'>

--- a/src/myComponents/PageLinks.css
+++ b/src/myComponents/PageLinks.css
@@ -11,3 +11,10 @@
   text-align: right;
   text-decoration: none;
 }
+
+@media (min-width: 991px) {
+  /* Make the page links take up the full width of our desktop flex layout */
+  .tng-PageLinks {
+    flex: 1 0 100%;
+  }
+}

--- a/src/myPages/Home.css
+++ b/src/myPages/Home.css
@@ -33,3 +33,25 @@
   padding: 5px 15px 0;
   word-spacing: 0.1em;
 }
+
+@media (min-width: 991px) {
+  /* Set a layout of 2 columns of articles */
+  .tng-Home-pageArticles {
+    align-items: flex-start;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    max-width: 960px;
+  }
+
+  /* Set width of each article to take a column width */
+  .tng-Home-item {
+    flex: 0 0 465px;
+    margin-bottom: 40px;
+  }
+
+  /* Remove the margin-top, it's replaced a margin-bottom instead */
+  .tng-Home-item + .tng-Home-item {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
This brings a change to our Home page that lays out the articles on 2 columns when the viewport is wider than 990px.

The other notable change is that article header's image-related widths are no longer fixed in pixels. The background shift effect will now work for any width that ArticleHeader is given. 