### PR TITLE
58 pt2: Add Importer component, to import page components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,39 +1,22 @@
+/**
+  * The Next Groove
+  * Our routes and global CSS is set here
+  */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Loadable from 'react-loadable'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import { Titled } from 'react-titled'
 import 'normalize.css'
 
 import './index.css'
+import Importer from 'myComponents/Importer'
 import NoContent from 'myPages/NoContent'
 
-const Loading = () => <div>Loading...</div>
-
-const About = Loadable({
-  loader: () => import('myPages/About'),
-  loading: Loading
-})
-
-const Admin = Loadable({
-  loader: () => import('myPages/Admin'),
-  loading: Loading
-})
-
-const Article = Loadable({
-  loader: () => import('myPages/Article'),
-  loading: Loading
-})
-
-const Category = Loadable({
-  loader: () => import('myPages/Category'),
-  loading: Loading
-})
-
-const Home = Loadable({
-  loader: () => import('myPages/Home'),
-  loading: Loading
-})
+const About = Importer(() => import('myPages/About'))
+const Admin = Importer(() => import('myPages/Admin'))
+const Article = Importer(() => import('myPages/Article'))
+const Category = Importer(() => import('myPages/Category'))
+const Home = Importer(() => import('myPages/Home'))
 
 const App = () => (
   <BrowserRouter>

--- a/src/myComponents/ArticleHeader.js
+++ b/src/myComponents/ArticleHeader.js
@@ -5,8 +5,8 @@
  */
 
 import React, { Component } from 'react'
-import OptionalLinkWrapper from './OptionalLinkWrapper'
 
+import OptionalLinkWrapper from './OptionalLinkWrapper'
 import './ArticleHeader.css'
 
 class ArticleHeader extends Component {

--- a/src/myComponents/Importer.js
+++ b/src/myComponents/Importer.js
@@ -1,0 +1,36 @@
+/**
+ * A component that wraps the react-loadable functionality, which dynamically imports a page
+ * component at the time that it is needed, thus providing easy code-splitting.
+ */
+import Loadable from 'react-loadable'
+import React from 'react'
+
+import ErrorIndicator from './ErrorIndicator'
+import LoadingIndicator from './LoadingIndicator'
+
+/**
+ * The Loading component that is a fill-in for the component we wish to import,
+ * until the moment that import is complete.
+ */
+const Loading = ({ error, pastDelay }) => {
+  if (error) {
+    return (
+      <ErrorIndicator>
+        Uh oh, we couldn&#39;t load this page<br />
+        Try to reload it.
+      </ErrorIndicator>
+    )
+  } else if (pastDelay) {
+    return <LoadingIndicator />
+  } else {
+    // it's still too early to show a loading component
+    return null
+  }
+}
+
+const Importer = (loader) => Loadable({
+  loader,
+  loading: Loading
+})
+
+export default Importer

--- a/src/myComponents/markdownRenderer/MarkdownImage.css
+++ b/src/myComponents/markdownRenderer/MarkdownImage.css
@@ -1,8 +1,5 @@
 .tng-MarkdownImage {
-  text-align: center;
-  width: 100%;
-}
-
-.tng-MarkdownImage-img {
+  display: block;
+  margin: 0 auto;
   max-width: 100%;
 }

--- a/src/myComponents/markdownRenderer/MarkdownImage.js
+++ b/src/myComponents/markdownRenderer/MarkdownImage.js
@@ -1,11 +1,11 @@
+/** A component to render an image that was provided in the Markdown of our article content */
 import React from 'react'
 
 import './MarkdownImage.css'
 
-const MarkdownImage = ({ alt, src }) => (
-  <div className='tng-MarkdownImage'>
-    <img alt={alt} className='tng-MarkdownImage-img' src={src} />
-  </div>
+// Note: top-level element cannot be a div, because images are wrapped with <p> elements
+const MarkdownImage = ({ alt, src, title }) => (
+  <img alt={alt} className='tng-MarkdownImage' src={src} title={title} />
 )
 
 export default MarkdownImage


### PR DESCRIPTION
Changes:
- Add Importer component, which makes use of react-loadable and a Loading component to dynamically import page components
- Cleaned up warning from Markdown image, regarding having <div> inside of <p>